### PR TITLE
fix typo and specify folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ---
 
-## Project Overview
+## About
 
-Diabetes is a chronic metabolic disease affecting millions of individuals worldwide. Early detection is essential to prevent severe complications such as cardiovascular disease, kidney damage, neuropathy, and vision impairment.
+This study investigates the use of machine learning techniques to predict diabetes status using clinical and demographic data from the Pima Indian Diabetes dataset. The dataset includes physiological variables such as glucose level, body mass index (BMI), age, and number of pregnancies.
 
-The goal of this project is to investigate whether diabetes status can be predicted using clinical and demographic features. Using the Pima Indian Diabetes dataset, we conduct exploratory data analysis (EDA) and develop a machine learning classification model to predict the presence of diabetes.
+A random forest classification model was developed to capture nonlinear relationships among predictors and improve prediction accuracy. The model demonstrated strong performance on the test dataset, achieving an accuracy of 88.9%, precision of 89.5%, recall of 94.0%, and an F1 score of 91.7%. The high recall indicates that the model is particularly effective at identifying individuals with diabetes, making it well-suited for screening and early detection applications.
 
 **Research Question:**  
 Can we predict the presence of diabetes in individuals based on clinical and demographic features?
@@ -24,132 +24,14 @@ The dataset originates from:
 - OpenML Dataset ID: 43483  
   https://www.openml.org/search?type=data&id=43483
 
-### Dataset Description
-
-- Population: Female patients, age 21 years or older  
-- Heritage: Pima Indian  
-- Number of observations: 768  
-- Target variable: `Outcome`  
-  - 0 = No diabetes  
-  - 1 = Diabetes  
-
-### Features
-
-- Pregnancies — Number of pregnancies  
-- Glucose — Plasma glucose concentration  
-- BloodPressure — Diastolic blood pressure  
-- SkinThickness — Triceps skinfold thickness  
-- Insulin — Serum insulin  
-- BMI — Body Mass Index  
-- DiabetesPedigreeFunction — Genetic predisposition score  
-- Age — Age in years  
-- Outcome — Diabetes diagnosis (binary)
-
-Approximately 35% of individuals in the dataset are diabetic.
-
----
-
-## Repository Structure
-
-```
-.
-├── .github/
-│   └── docker-image.yml
-├── data/
-│   └── pima_indian_diabetes.csv
-├── src/
-│   ├── predicting_diabetes.Rmd
-│   └── predicting_diabetes.html
-├── renv/
-│   ├── .gitignore
-│   ├── active.R
-│   └── settings.json
-├── .Rprofile
-├── .gitignore
-├── CODE_OF_CONDUCT.md
-├── Dockerfile
-├── LICENSE
-├── README.md
-├── dsci-310-group-10.Rproj
-└── renv.lock
-```
-
----
-
-## Methods
-
-### Exploratory Data Analysis (EDA)
-
-We performed:
-
-- Summary statistics  
-- Missing value checks  
-- Correlation analysis  
-- Density plots by outcome  
-- Pairwise scatterplot matrices  
-
-Key findings:
-
-- Glucose is the strongest predictor of diabetes.
-- BMI, Age, and Pregnancies are positively associated with diabetes.
-- Moderate class imbalance exists (~35% diabetic).
-
----
-
-### Model Development
-
-We trained a Random Forest classifier using:
-
-- 80/20 stratified train-test split  
-- 500 decision trees  
-
-Random Forest was chosen because it:
-
-- Captures nonlinear relationships  
-- Handles feature interactions  
-- Is robust to overfitting  
-- Performs well on structured clinical data  
-
----
-
-## Model Evaluation
-
-Performance metrics:
-
-| Metric     | Value  |
-|------------|--------|
-| Accuracy   | 88.9%  |
-| Precision  | 89.5%  |
-| Recall     | 94.0%  |
-| F1 Score   | 91.7%  |
-
-### Interpretation
-
-- High recall indicates strong detection of diabetic patients.
-- High precision reduces false positives.
-- Strong F1 score reflects balanced classification performance.
-
-The model may serve as a useful screening tool but is not a substitute for clinical diagnosis.
-
----
-
-## Limitations
-
-- Dataset includes only female participants.
-- Results may not generalize to other populations.
-- External validation is needed.
-- Advanced models (e.g., gradient boosting) could be explored.
-
----
-
 ## Reproducibility
 
 This project uses `renv` for reproducible package management.
 
 
-### Usage (pick one method from below)
+## Usage (pick one method from below)
 
-#### 1. Using renv
+### 1. Using renv
 
 A. Open your terminal.
 
@@ -166,7 +48,6 @@ git clone https://github.com/UBC-DSCI-310-2025W2/dsci-310-group-10.git
 ```
 
 D. Open the project folder in RStudio (inside RStudio, click "File" then "open project", and select dsci-310-group-10)
-
 
 E. Restore environment:
 
@@ -193,7 +74,7 @@ G. To reproduce results:
 
 ---
 
-#### 2. Using Docker compose to launch containers
+### 2. Using Docker compose to launch containers
 
 A. Open your terminal.
 
@@ -248,7 +129,7 @@ I. To stop and clean up the container, you would use Ctrl + c in the terminal wh
 docker-compose down
 ```
 
-#### 3. Manually launch docker containers
+### 3. Manually launch docker containers
 
 A. Open your terminal.
 
@@ -295,9 +176,27 @@ H. To reproduce results:
 Open src/predicting_diabetes.Rmd
 Click Run All
 
+### Running the Pipeline
+
+This project uses a Makefile to automate the analysis workflow.
+
+To run the full pipeline and generate all outputs (including processed data, models, and the final report), run:
+
+```bash
+make all
+```
+
+To remove all generated files and reset the project to a clean state, run:
+
+```bash
+make clean
+```
+
+make clean will delete intermediate and output files so the pipeline can be run again from scratch.
+
 ---
 
-### Dependencies
+## Dependencies
 
 - R version 4.5.2 and R packages:
 - caret=7.0-1
@@ -319,7 +218,7 @@ All package versions and additional dependencies are recorded in the renv.lock f
 
 ---
 
-### License
+## License
 This project is licensed under the Creative Commons Attribution 2.5 Canada License (CC BY 2.5 CA).
 
 Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)


### PR DESCRIPTION
Fixed according to the Gradescope feedback:

1. The instructions did not include navigating into the repository after cloning (e.g., cd dsci-310-group-10), which may prevent subsequent steps from running correctly
2. There was a typo in the file path (scr/ instead of src/), which could interrupt the workflow